### PR TITLE
js+cpp: Convenience method to load WebP to BitmapData asynchronously. 

### DIFF
--- a/src/webp/WebP.hx
+++ b/src/webp/WebP.hx
@@ -7,6 +7,8 @@ import cpp.UInt8;
 import sys.io.File;
 import webp._internal.Decode;
 #end
+
+import haxe.Exception;
 import haxe.io.Bytes;
 import lime.graphics.Image;
 import lime.graphics.ImageBuffer;
@@ -112,6 +114,31 @@ class WebP
 			#if windows BGRA32 #else RGBA32 #end));
 		#else
 		throw new Exception("Loading WebP files from bytes is not supported on this platform!");
+		#end
+	}
+
+	/**
+		Loads bitmap data. Works in cpp and html5, html5 load webp asynchronously via Lime (in supported browsers)
+		@param	file		The asset path of the WebP
+		@return		A new Image object
+	**/
+	public static function loadBitmapDataFromBytes(bytes:Bytes, onComplete:BitmapData->Void):Void {
+		#if cpp
+			var bitmapFromBytes = getBitmapDataFromBytes(bytes);
+			onComplete(bitmapFromBytes);
+			return;
+		#end
+		#if (js && html5)
+			var data_b64 = haxe.crypto.Base64.encode(bytes);
+			var limg_future = lime.graphics.Image.loadFromBase64(data_b64,"image/webp");
+			limg_future.onComplete (function (image) { 
+				var bitmapData = BitmapData.fromImage(image, true);
+				onComplete(bitmapData);
+			});
+			limg_future.onError (function (error) { 
+				onComplete(null);
+			});
+			return;
 		#end
 	}
 }


### PR DESCRIPTION
Thanks for the lib! Working like a charm :) The only inconvenience - it throw errors in html5 builds (also html5 not building out-of-the-box due missing import.

To make library more unified between targets, I added loading of webp bitmapdata for html5 target (via Lime). With this method webp can be loaded into bitmap data in cpp && html5 target with same code. Hope you find it useful!